### PR TITLE
Fatal Error fix

### DIFF
--- a/simple/public/index.php
+++ b/simple/public/index.php
@@ -2,6 +2,7 @@
 
 use Phalcon\Di;
 use Phalcon\Loader;
+use Phalcon\Mvc\Application;
 use Phalcon\Mvc\View;
 use Phalcon\Mvc\Router;
 use Phalcon\Http\Request;


### PR DESCRIPTION
fixes an error "Fatal error: Class 'Application' not found in /public/index.php on line 81" caused by Phalcon\Mvc\Application not being included